### PR TITLE
update deprecated boost url

### DIFF
--- a/org.aegisub.Aegisub.yml
+++ b/org.aegisub.Aegisub.yml
@@ -166,7 +166,7 @@ modules:
               type: anitya
               project-id: 6845
               stable-only: true
-              url-template: https://boostorg.jfrog.io/artifactory/main/release/$version/source/boost_${major}_${minor}_${patch}.tar.gz
+              url-template: https://archives.boost.io/release/$version/source/boost_${major}_${minor}_${patch}.tar.gz
       - name: LuaJIT
         buildsystem: autotools
         no-autogen: true


### PR DESCRIPTION


Download repository url has moved

refer: https://lists.boost.org/Archives/boost/2024/05/256914.php
