### PR TITLE
wxwidgets: update to `v3.3.x`

### DIFF
--- a/org.aegisub.Aegisub.yml
+++ b/org.aegisub.Aegisub.yml
@@ -17,7 +17,7 @@ finish-args:
   - --socket=wayland
   - --device=dri
   - --socket=pulseaudio
-  - --filesystem=home
+  - --env=GTK_USE_PORTAL=1
 # TODO: Consider separate locales
 separate-locales: false
 cleanup:
@@ -49,7 +49,7 @@ modules:
       # Other
       - -Dfftw3=enabled
       - -Dsystem_luajit=true
-      - -Dwx_version=3.2.6
+      - -Dwx_version=3.3.1
       - -Dcredit="zefr0x"
       - -Denable_update_checker=false
       - --buildtype=release
@@ -87,8 +87,8 @@ modules:
         sources:
           - type: git
             url: https://github.com/wxWidgets/wxWidgets.git
-            tag: v3.2.8
-            commit: 8aef5f40b93958719771331ca03866b7b6fff6bf
+            tag: v3.3.1
+            commit: 49c6810948f40c457e3d0848b9111627b5b61de5
             x-checker-data:
               type: git
               tag-pattern: ^v(\d*\.\d*\.\d*)$

--- a/org.aegisub.Aegisub.yml
+++ b/org.aegisub.Aegisub.yml
@@ -17,7 +17,7 @@ finish-args:
   - --socket=wayland
   - --device=dri
   - --socket=pulseaudio
-  - --filesystem=home
+  - --env=GTK_USE_PORTAL=1
 add-extensions:
   org.aegisub.Aegisub.Automations:
     directory: automations
@@ -72,7 +72,7 @@ modules:
       # Other
       - -Dfftw3=enabled
       - -Dsystem_luajit=true
-      - -Dwx_version=3.2.6
+      - -Dwx_version=3.3.2
       - -Dcredit="zefr0x"
       - -Denable_update_checker=false
       - --buildtype=release
@@ -97,7 +97,6 @@ modules:
           # TODO: Disable more unused features to fast up compiling.
           - -DCMAKE_BUILD_TYPE=Release
           - -DwxBUILD_TOOLKIT=gtk3
-          - -DwxUSE_BASE64=OFF
           - -DwxUSE_GIF=OFF
           - -DwxUSE_LIBJPEG=OFF
           - -DwxUSE_SVG=OFF
@@ -113,8 +112,8 @@ modules:
         sources:
           - type: git
             url: https://github.com/wxWidgets/wxWidgets.git
-            tag: v3.2.8
-            commit: 8aef5f40b93958719771331ca03866b7b6fff6bf
+            tag: v3.3.2
+            commit: db1005db3dea2c37a46fb455a9a02e37aa360751
             x-checker-data:
               type: git
               tag-pattern: ^v(\d*\.\d*\.\d*)$


### PR DESCRIPTION
wxwidgets v3.3.x has some [breaking changes](https://raw.githubusercontent.com/wxWidgets/wxWidgets/v3.3.0/docs/changes.txt), which should be resolved in upstream Aegisub before merging this.

Closes: #10